### PR TITLE
Fix CSS

### DIFF
--- a/js/browser-ui.js
+++ b/js/browser-ui.js
@@ -57,7 +57,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     }
 
     holder.classList.add('dalliance');
-    var toolbar = b.toolbar = makeElement('div', null, {className: 'btn-toolbar toolbar'});
+    var toolbar = b.toolbar = makeElement('div', null, {className: 'btn-toolbar toolbar row'});
 
     var title = b.coordSystem.speciesName + ' ' + b.nameForCoordSystem(b.coordSystem);
     if (this.setDocumentTitle) {
@@ -66,7 +66,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
 
     var locField = makeElement('input', '', {className: 'loc-field'});
     b.makeTooltip(locField, 'Enter a genomic location or gene name');
-    var locStatusField = makeElement('p', '', {className: 'loc-status'});
+    var locStatusField = makeElement('p', '', {className: 'loc-status col-2'});
 
     var zoomInBtn = makeElement('a', [makeElement('i', null, {className: 'fa fa-search-plus'})], {className: 'btn'});
     var zoomSlider = new makeZoomSlider({width: b.zoomSliderWidth});
@@ -86,10 +86,10 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     var tierEditButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-road'})], {className: 'btn'});
     b.makeTooltip(tierEditButton, 'Configure currently selected track(s) (E)')
 
-    var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn'}, {width: '5px'});
-    var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right'}, {width: '5px'});
+    var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn ml-3'}, {width: '5px'});
+    var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right mr-3'}, {width: '5px'});
 
-    var modeButtons = makeElement('div', null, {className: 'btn-group pull-right'});
+    var modeButtons = makeElement('div', null, {className: 'btn-group pull-right ml-auto'});
     if (!this.noTrackAdder)
         modeButtons.appendChild(addTrackBtn);
     if (!this.noTrackEditor)
@@ -113,26 +113,30 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     }
 
     if (!this.noLeapButtons)
-        toolbar.appendChild(leapRightButton);
-
-    if (modeButtons.firstChild)
-        toolbar.appendChild(modeButtons);
-    
-    if (!this.noLeapButtons)
         toolbar.appendChild(leapLeftButton);
+
     if (!this.noTitle) {
         toolbar.appendChild(makeElement('div', makeElement('h4', title, {}, {margin: '0px'}), {className: 'btn-group title'}));
     }
+
     if (!this.noLocationField)
         toolbar.appendChild(makeElement('div', [locField, locStatusField], {className: 'btn-group loc-group'}));
+
     if (!this.noClearHighlightsButton)
         toolbar.appendChild(clearHighlightsButton);
 
     if (!this.noZoomSlider) {
         toolbar.appendChild(makeElement('div', [zoomInBtn,
-                                                makeElement('span', zoomSlider, {className: 'btn'}),
+                                                makeElement('span', zoomSlider, {className: 'btn ml'}),
                                                 zoomOutBtn], {className: 'btn-group'}));
     }
+
+    if (modeButtons.firstChild)
+        toolbar.appendChild(modeButtons);
+    
+    if (!this.noLeapButtons)
+        toolbar.appendChild(leapRightButton);
+    
     
     if (this.toolbarBelow) {
         holder.appendChild(genomePanel);

--- a/js/browser-ui.js
+++ b/js/browser-ui.js
@@ -57,7 +57,7 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     }
 
     holder.classList.add('dalliance');
-    var toolbar = b.toolbar = makeElement('div', null, {className: 'btn-toolbar toolbar'});
+    var toolbar = b.toolbar = makeElement('div', null, {className: 'btn-toolbar toolbar row'});
 
     var title = b.coordSystem.speciesName + ' ' + b.nameForCoordSystem(b.coordSystem);
     if (this.setDocumentTitle) {
@@ -86,10 +86,10 @@ Browser.prototype.initUI = function(holder, genomePanel) {
     var tierEditButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-road'})], {className: 'btn'});
     b.makeTooltip(tierEditButton, 'Configure currently selected track(s) (E)')
 
-    var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn'}, {width: '5px'});
-    var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right'}, {width: '5px'});
+    var leapLeftButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-left'})], {className: 'btn ml-3'}, {width: '5px'});
+    var leapRightButton = makeElement('a', [makeElement('i', null, {className: 'fa fa-angle-right'})], {className: 'btn pull-right mr-3'}, {width: '5px'});
 
-    var modeButtons = makeElement('div', null, {className: 'btn-group pull-right'});
+    var modeButtons = makeElement('div', null, {className: 'btn-group pull-right ml-auto'});
     if (!this.noTrackAdder)
         modeButtons.appendChild(addTrackBtn);
     if (!this.noTrackEditor)
@@ -111,15 +111,9 @@ Browser.prototype.initUI = function(holder, genomePanel) {
                 mb[x].classList.remove('active');
         }
     }
-
-    if (!this.noLeapButtons)
-        toolbar.appendChild(leapRightButton);
-
-    if (modeButtons.firstChild)
-        toolbar.appendChild(modeButtons);
-    
     if (!this.noLeapButtons)
         toolbar.appendChild(leapLeftButton);
+    
     if (!this.noTitle) {
         toolbar.appendChild(makeElement('div', makeElement('h4', title, {}, {margin: '0px'}), {className: 'btn-group title'}));
     }
@@ -133,6 +127,12 @@ Browser.prototype.initUI = function(holder, genomePanel) {
                                                 makeElement('span', zoomSlider, {className: 'btn'}),
                                                 zoomOutBtn], {className: 'btn-group'}));
     }
+
+    if (modeButtons.firstChild)
+        toolbar.appendChild(modeButtons);
+
+    if (!this.noLeapButtons)
+        toolbar.appendChild(leapRightButton);
     
     if (this.toolbarBelow) {
         holder.appendChild(genomePanel);

--- a/js/version.js
+++ b/js/version.js
@@ -14,7 +14,7 @@ var VERSION = {
     MAJOR:  0,
     MINOR:  13,
     MICRO:  7,
-    BRANCH: 'dev'
+    BRANCH: 'Helix-dev'
 };
 
 VERSION.toString = function() {


### PR DESCRIPTION
# What this PR does

This PR updates the browser-ui.js file to make the toolbar button layout appear the same in bootstrap 4 as it does in bootstrap 2 (what it was originally developed for). It should have backwards compatability with bootstrap 2, but this has not been explicitly checked and is not in scope. 

This PR also updates the version.js file to display the version as 'Helix-dev' instead of 'dev'. 